### PR TITLE
Fix ContactsController, App.Routes test

### DIFF
--- a/src/app/common/app.spec.js
+++ b/src/app/common/app.spec.js
@@ -11,7 +11,7 @@ describe('App', function () {
   beforeEach(module('components.auth'));
 
   beforeEach(module(function ($stateProvider) {
-    $stateProvider.state('contacts', { url: 'app/contacts' });
+    $stateProvider.state('contacts', { url: '/app/contacts' });
   }));
 
   describe('Routes', function () {

--- a/src/app/components/contact/contacts/contacts.controller.js
+++ b/src/app/components/contact/contacts/contacts.controller.js
@@ -1,8 +1,9 @@
 function ContactsController($filter, $state) {
   var ctrl = this;
-  var contacts = ctrl.contacts;
 
-  ctrl.filteredContacts = $filter('contactsFilter')(contacts, ctrl.filter);
+  ctrl.$onInit = function() {
+    ctrl.filteredContacts = $filter('contactsFilter')(ctrl.contacts, ctrl.filter);
+  };
 
   ctrl.goToContact = function (event) {
     $state.go('contact', {

--- a/src/app/components/contact/contacts/contacts.spec.js
+++ b/src/app/components/contact/contacts/contacts.spec.js
@@ -45,7 +45,7 @@ describe('Contact', function () {
     });
   });
 
-  describe('ContactController', function () {
+  describe('ContactsController', function () {
     var $componentController,
       controller,
       $filter,
@@ -70,6 +70,7 @@ describe('Contact', function () {
         { $scope: {}, $filter: $filter, $state: $state },
         { filter: mockFilter, contacts: mockContacts }
       );
+      controller.$onInit();
     }));
 
     it('should filter contacts', function() {


### PR DESCRIPTION
Issue ref #16 

_Add $onInit function to pass contacts, filter values to contactsFilter's constructor.
Call $onInit function for controller initialization.
Rename 'ConctactController' test name to 'ContactsController'._

Issue ref #18 

_Change url definition for contacts state app/contacts -> /app/contacts._